### PR TITLE
Some Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A tiny Selenium wrapper written in pure VBA.
 
 # ✨ Features
 
-- No insatallation: Everyone even who doesn't have permissions to install can automate browser operations.
+- No installation: Everyone even who doesn't have permissions to install can automate browser operations.
 - Useful helper Methods: FindElement(s)By*, Get/Set value to form, click and more.
 - Open spec: Basically this wrapper is just a HTTP client of WebDriver server. Learning this wrapper equals to learning WebDriver.
 https://www.w3.org/TR/webdriver/

--- a/WebDriver.cls
+++ b/WebDriver.cls
@@ -167,7 +167,9 @@ Public CMD_SWITCH_TO_CONTEXT
 Public CMD_FULLSCREEN_WINDOW
 Public CMD_MINIMIZE_WINDOW
 Public CMD_SHUTDOWN
-
+'
+Private Const DRIVE_URL = "http://localhost:9515"
+'
 Private Const ELEMENT_KEY = "element-6066-11e4-a52e-4f735466cecf"
 
 Public Enum By
@@ -184,12 +186,12 @@ End Enum
 ' ==========================================================================
 
 ' Launch Edge Driver
-Public Sub Edge(ByVal driverPath As String, Optional ByVal driverUrl As String = "http://localhost:9515")
+Public Sub Edge(ByVal driverPath As String, Optional ByVal driverUrl As String = DRIVE_URL)
     Start driverPath, driverUrl
 End Sub
 
 ' Launch Chrome Driver
-Public Sub Chrome(ByVal driverPath As String, Optional ByVal driverUrl As String = "http://localhost:9151")
+Public Sub Chrome(ByVal driverPath As String, Optional ByVal driverUrl As String = DRIVE_URL)
     Start driverPath, driverUrl
 End Sub
 

--- a/WebDriver.cls
+++ b/WebDriver.cls
@@ -178,6 +178,7 @@ Public Enum By
     ClassName = 2
     Name = 3
     CssSelector = 4
+    Xpath = 5
 End Enum
 
 

--- a/WebDriver.cls
+++ b/WebDriver.cls
@@ -314,20 +314,31 @@ Public Function FindElements(by_ As By, value As String, Optional parentElementI
     FindElements = ret
 End Function
 
-' by* to CSS selector
+' by* to CSS selector or Xpath
 Private Function ToSelector(by_ As By, ByVal value As String) As Dictionary
-    If by_ = By.ID Then
-        value = "[id=""" + value + """]"
-    ElseIf by_ = By.ClassName Then
-        value = "." + value
-    ElseIf by_ = By.Name Then
-        value = "[name=""" + value + """]"
-    End If
-    
+    '
     Dim data As New Dictionary
-    data.Add "using", "css selector"
+    '
+    If (by_ = By.Xpath) Then
+        '
+        'Locator Strategy XPath
+        data.Add "using", "xpath"
+    Else:
+        '
+        'Use Css Selector for Locator strategies other than
+        data.Add "using", "css selector"
+        '
+        If by_ = By.ID Then
+            value = "[id=""" + value + """]"
+        ElseIf by_ = By.ClassName Then
+            value = "." + value
+        ElseIf by_ = By.Name Then
+            value = "[name=""" + value + """]"
+        End If
+    End If
+    '
     data.Add "value", value
-    
+    '
     Set ToSelector = data
 End Function
 


### PR DESCRIPTION
**Fixed driverUrl**
Fixed driverUrl value in `Sub Chrome(ByVal driverPath As String, Optional ByVal driverUrl As String)`
The default value of `driverUrl` in this Sub was set to "http://localhost:9151" instead of "http://localhost:9515" which was causing an error while trying to start Chrome browser
To prevent this, it was created a `Const DRIVER_URL` with the right address to WebDriver and, as this address is the same with both EdgeDriver and ChromeDriver and can be used as the default value of Sub Chrome and Sub Edge
**Enabled FindElement by Xpath**
Added code to enable FindElement by Xpath solving the Issue #2 