### PR TITLE
Make it easier to configure Capabilities

### DIFF
--- a/Capabilities.cls
+++ b/Capabilities.cls
@@ -1,0 +1,248 @@
+VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = "Capabilities"
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Creatable = False
+Attribute VB_PredeclaredId = False
+Attribute VB_Exposed = False
+' TinySeleniumVBA v0.1.2
+' A tiny Selenium wrapper written in pure VBA
+'
+' (c)2021 uezo
+'
+' Mail: uezo@uezo.net
+' Twitter: @uezochan
+' https://github.com/uezo/TinySeleniumVBA
+'
+' ==========================================================================
+' MIT License
+'
+' Copyright (c) 2021 uezo
+'
+' Permission is hereby granted, free of charge, to any person obtaining a copy
+' of this software and associated documentation files (the "Software"), to deal
+' in the Software without restriction, including without limitation the rights
+' to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+' copies of the Software, and to permit persons to whom the Software is
+' furnished to do so, subject to the following conditions:
+'
+' The above copyright notice and this permission notice shall be included in all
+' copies or substantial portions of the Software.
+'
+' THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+' IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+' FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+' AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+' LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+' OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+' SOFTWARE.
+' ==========================================================================
+
+Option Explicit
+
+Public Root As New Dictionary
+Private BrowserOptionKey As String
+
+' Spec of capabilities:
+' - Chrome: https://chromedriver.chromium.org/capabilities
+' - Edge: https://docs.microsoft.com/en-us/microsoft-edge/webdriver-chromium/capabilities-edge-options
+
+' Getters and Setters
+Public Property Let args(value() As String)
+    SetOption "args", value
+End Property
+
+Public Property Get args() As String()
+    args = GetOption("args")
+End Property
+
+Public Property Let binary(ByVal value As String)
+    SetOption "binary", value
+End Property
+
+Public Property Get binary() As String
+    binary = GetOption("binary")
+End Property
+
+Public Property Let extensions(value() As String)
+    SetOption "extensions", value
+End Property
+
+Public Property Get extensions() As String()
+    extensions = GetOption("extensions")
+End Property
+
+Public Property Set localState(ByVal value As Dictionary)
+    SetOption "localState", value
+End Property
+
+Public Property Get localState() As Dictionary
+    Set localState = GetOption("localState")
+End Property
+
+Public Property Set prefs(value As Dictionary)
+    SetOption "prefs", value
+End Property
+
+Public Property Get prefs() As Dictionary
+    Set prefs = GetOption("prefs")
+End Property
+
+Public Property Let detach(value As Boolean)
+    SetOption "detach", value
+End Property
+
+Public Property Get detach() As Boolean
+    detach = GetOption("detach")
+End Property
+
+Public Property Let debuggerAddress(ByVal value As String)
+    SetOption "debuggerAddress", value
+End Property
+
+Public Property Get debuggerAddress() As String
+    debuggerAddress = GetOption("debuggerAddress")
+End Property
+
+Public Property Let excludeSwitches(value() As String)
+    SetOption "excludeSwitches", value
+End Property
+
+Public Property Get excludeSwitches() As String()
+    excludeSwitches = GetOption("excludeSwitches")
+End Property
+
+Public Property Let minidumpPath(ByVal value As String)
+    SetOption "minidumpPath", value
+End Property
+
+Public Property Get minidumpPath() As String
+    minidumpPath = GetOption("minidumpPath")
+End Property
+
+Public Property Set mobileEmulation(value As Dictionary)
+    SetOption "mobileEmulation", value
+End Property
+
+Public Property Get mobileEmulation() As Dictionary
+    Set mobileEmulation = GetOption("mobileEmulation")
+End Property
+
+Public Property Set perfLoggingPrefs(value As Dictionary)
+    SetOption "perfLoggingPrefs", value
+End Property
+
+Public Property Get perfLoggingPrefs() As Dictionary
+    Set perfLoggingPrefs = GetOption("perfLoggingPrefs")
+End Property
+
+Public Property Let windowTypes(ByVal value As String)
+    SetOption "windowTypes", value
+End Property
+
+Public Property Get windowTypes() As String
+    windowTypes = GetOption("windowTypes")
+End Property
+
+Public Sub SetOption(ByVal key As String, value As Variant)
+    If IsObject(value) Then
+        Set Root("alwaysMatch")(BrowserOptionKey)(key) = value
+    Else
+        Root("alwaysMatch")(BrowserOptionKey)(key) = value
+    End If
+End Sub
+
+Public Function GetOption(ByVal key As String) As Variant
+    If IsObject(Root("alwaysMatch")(BrowserOptionKey)(key)) Then
+        Set GetOption = Root("alwaysMatch")(BrowserOptionKey)(key)
+    Else
+        GetOption = Root("alwaysMatch")(BrowserOptionKey)(key)
+    End If
+End Function
+
+' Helper method to add argument
+Public Sub AddArgument(ByVal argument As String)
+    Dim arguments() As String
+    Dim idx As Integer: idx = -1
+
+    ' idx will not be updated when args is Nothing or args has no items
+    On Error Resume Next
+    idx = UBound(args)
+    On Error GoTo 0
+    
+    If idx >= 0 Then
+        arguments = args
+    End If
+        
+    ReDim Preserve arguments(idx + 1)
+    arguments(UBound(arguments)) = argument
+    
+    args = arguments
+End Sub
+
+' Helper method to set arguments
+Public Sub SetArguments(ByVal value As String, Optional ByVal delimiter As String = " ")
+    SetOption "args", Split(value, delimiter)
+End Sub
+
+' Helper method to add prefs
+Public Sub AddPref(ByVal key As String, ByVal value As String)
+    If prefs Is Nothing Then
+        SetOption "prefs", New Dictionary
+    End If
+    prefs(key) = value
+End Sub
+
+' Convert to JSON string for debugging
+Public Function ToJson() As String
+    ToJson = JsonConverter.ConvertToJson(Root)
+End Function
+
+' Initializer for each browser
+Public Sub InitializeFor(ByVal BrowserName As String, Optional ByVal optionKey As String)
+    Set Root = New Dictionary
+    Root.Add "browserName", BrowserName
+    Root.Add "alwaysMatch", New Dictionary
+    
+    ' Add browser option keys for chromium like browsers. If value is not set, the option will not appear in JSON
+    Dim browserOptions As New Dictionary
+    browserOptions.Add "args", Nothing
+    browserOptions.Add "binary", Nothing
+    browserOptions.Add "extensions", Nothing
+    browserOptions.Add "localState", Nothing
+    browserOptions.Add "prefs", Nothing
+    browserOptions.Add "detach", Nothing
+    browserOptions.Add "debuggerAddress", Nothing
+    browserOptions.Add "excludeSwitches", Nothing
+    browserOptions.Add "minidumpPath", Nothing
+    browserOptions.Add "mobileEmulation", Nothing
+    browserOptions.Add "perfLoggingPrefs", Nothing
+    browserOptions.Add "windowTypes", Nothing
+    
+    Select Case LCase(BrowserName)
+        Case "chrome"
+            BrowserOptionKey = "goog:chromeOptions"
+
+        Case "microsoftedge"
+            BrowserOptionKey = "ms:edgeOptions"
+
+        Case Else
+            BrowserOptionKey = optionKey
+        
+        'TODO: Add default options for browsers
+    End Select
+    
+    Root("alwaysMatch").Add BrowserOptionKey, browserOptions
+End Sub
+
+' Shortcut initializer for chrome
+Public Sub InitializeForChrome()
+    InitializeFor "chrome"
+End Sub
+
+' Shortcut initializer for edge
+Public Sub InitializeForEdge()
+    InitializeFor "MicrosoftEdge"
+End Sub

--- a/README.ja.md
+++ b/README.ja.md
@@ -58,6 +58,34 @@ Public Sub main()
 End Sub
 ```
 
+# 🐙 ブラウザーオプション
+
+ブラウザーオプションを指定するには `Capabilities` を使うと便利です。以下はヘッドレスモード（非表示モード）でブラウザを起動する例です。
+
+```vb
+' Start web driver
+Dim Driver As New WebDriver
+Driver.Chrome "C:\Users\uezo\Desktop\chromedriver.exe"
+
+' Configure Capabilities
+Dim cap As Capabilities
+Set cap = Driver.CreateCapabilities()
+cap.AddArgument "--headless"
+' Use SetArguments if you want to add multiple arguments
+' cap.SetArguments "--headless --xxx -xxx"
+
+' Show Capabilities as JSON for debugging
+Debug.Print cap.ToJson()
+
+' Open browser
+Driver.OpenBrowser cap
+```
+
+`Capabilities`の仕様はブラウザ毎に異なりますので、以下のWebサイト等にてご確認ください。
+- Chrome: https://chromedriver.chromium.org/capabilities
+- Edge: https://docs.microsoft.com/en-us/microsoft-edge/webdriver-chromium/capabilities-edge-options
+
+
 # ❤️ 謝辞
 
 [VBA-JSON](https://github.com/VBA-tools/VBA-JSON) という Tim Hall さんが開発したVBA用JSONコンバーターはHTTPクライアントを作る上でとても役に立ちました。このすばらしいライブラリは当該ライブラリのライセンスのもとでリリースに含まれています。ありがとうございます！

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Public Sub main()
     ' Start WebDriver (Edge)
     Dim Driver As New WebDriver
     Driver.Edge "path\to\msedgedriver.exe"
-    
+
     ' Open browser
     Driver.OpenBrowser
     
@@ -57,6 +57,33 @@ Public Sub main()
     Driver.Execute Driver.CMD_REFRESH
 End Sub
 ```
+
+# 🐙 BrowserOptions
+
+Use `Capabilities` to configure browser options. This is an example to launch browser as headless (invisible) mode.
+
+```vb
+' Start web driver
+Dim Driver As New WebDriver
+Driver.Chrome "C:\Users\uezo\Desktop\chromedriver.exe"
+
+' Configure Capabilities
+Dim cap As Capabilities
+Set cap = Driver.CreateCapabilities()
+cap.AddArgument "--headless"
+' Use SetArguments if you want to add multiple arguments
+' cap.SetArguments "--headless --xxx -xxx"
+
+' Show Capabilities as JSON for debugging
+Debug.Print cap.ToJson()
+
+' Open browser
+Driver.OpenBrowser cap
+```
+
+See also the sites below to understand the spec of `Capabilities` for each browser.
+- Chrome: https://chromedriver.chromium.org/capabilities
+- Edge: https://docs.microsoft.com/en-us/microsoft-edge/webdriver-chromium/capabilities-edge-options
 
 # ❤️ Thanks
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -57,6 +57,33 @@ Public Sub main()
 End Sub
 ```
 
+# 🐙 BrowserOptions
+
+Utilize `Capabilities` para configurar as opções do navegador. Este é um exemplo para lançar o browser como modo sem cabeça (invisível).
+
+```vb
+' Start web driver
+Dim Driver As New WebDriver
+Driver.Chrome "C:\Users\uezo\Desktop\chromedriver.exe"
+
+' Configure Capabilities
+Dim cap As Capabilities
+Set cap = Driver.CreateCapabilities()
+cap.AddArgument "--headless"
+' Use SetArguments if you want to add multiple arguments
+' cap.SetArguments "--headless --xxx -xxx"
+
+' Show Capabilities as JSON for debugging
+Debug.Print cap.ToJson()
+
+' Open browser
+Driver.OpenBrowser cap
+```
+
+Ver também os sites abaixo para compreender as especificações de `Capabilities` para cada navegador.
+- Chrome: https://chromedriver.chromium.org/capabilities
+- Edge: https://docs.microsoft.com/en-us/microsoft-edge/webdriver-chromium/capabilities-edge-options
+
 # ❤️ Agradecimentos
 
 [VBA-JSON](https://github.com/VBA-tools/VBA-JSON) de Tim Hall, um conversor de JSON para VBA que auxilia muito ao fazer um cliente HTTP. Esta valiosa biblioteca está inclusa nesta versão junto com sua respectiva licença. Muito obrigado!

--- a/WebDriver.cls
+++ b/WebDriver.cls
@@ -7,7 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
-' TinySeleniumVBA v0.1.0
+' TinySeleniumVBA v0.1.2
 ' A tiny Selenium wrapper written in pure VBA
 '
 ' (c)2021 uezo
@@ -176,8 +176,10 @@ Public Enum By
     ClassName = 2
     Name = 3
     CssSelector = 4
-    Xpath = 5
+    XPath = 5
 End Enum
+
+Public BrowserName As String
 
 
 ' ==========================================================================
@@ -186,16 +188,23 @@ End Enum
 
 ' Launch Edge Driver
 Public Sub Edge(ByVal driverPath As String, Optional ByVal driverUrl As String = "http://localhost:9515")
-    Start driverPath, driverUrl
+    Start driverPath, driverUrl, "MicrosoftEdge"
 End Sub
 
 ' Launch Chrome Driver
 Public Sub Chrome(ByVal driverPath As String, Optional ByVal driverUrl As String = "http://localhost:9515")
-    Start driverPath, driverUrl
+    Start driverPath, driverUrl, "chrome"
 End Sub
 
+' Get default capabilities for current browser
+Public Function CreateCapabilities()
+    Dim cap As New Capabilities
+    cap.InitializeFor BrowserName
+    Set CreateCapabilities = cap
+End Function
+
 ' Start WebDriver
-Public Sub Start(ByVal driverPath As String, ByVal driverUrl As String)
+Public Sub Start(ByVal driverPath As String, ByVal driverUrl As String, Optional ByVal driverName As String = vbNullString)
     ' Start WebDriver executable
     If Shell(driverPath, vbMinimizedNoFocus) = 0 Then
         MsgBox "Failed in starting WebDriver"
@@ -207,6 +216,9 @@ Public Sub Start(ByVal driverPath As String, ByVal driverUrl As String)
     
     ' Initialize driver commands
     InitCommands
+    
+    ' Set browser name
+    BrowserName = driverName
 End Sub
 
 ' Shutdown WebDriver
@@ -220,13 +232,20 @@ End Sub
 ' ==========================================================================
 
 ' Open browser
-Public Function OpenBrowser(Optional capabilities As Dictionary = Nothing, Optional desiredCapabilities As Dictionary = Nothing, Optional ByVal useAsDefault As Boolean = True) As String
-    If capabilities Is Nothing Then
-        Set capabilities = New Dictionary
+Public Function OpenBrowser(Optional Capabilities As Object = Nothing, Optional desiredCapabilities As Dictionary = Nothing, Optional ByVal useAsDefault As Boolean = True) As String
+    Dim capDict As Dictionary
+    If TypeName(Capabilities) = "Dictionary" Then
+        Set capDict = Capabilities
+    ElseIf TypeName(Capabilities) = "Capabilities" Then
+        Set capDict = Capabilities.Root
+    ElseIf Capabilities Is Nothing Then
+        Set capDict = New Dictionary
+    Else
+        Err.Raise 13, "WebDriver.OpenBrowser", "Argument capabilities must be an instance of Capabilities or Dictionary"
     End If
-    
+
     Dim resp As Dictionary
-    Set resp = Execute(CMD_NEW_SESSION, Params("capabilities", capabilities, "desiredCapabilities", desiredCapabilities))
+    Set resp = Execute(CMD_NEW_SESSION, Params("capabilities", capDict, "desiredCapabilities", desiredCapabilities))
     
     If useAsDefault Then
         DefaultSessionId = resp("sessionId")
@@ -316,7 +335,7 @@ End Function
 ' by* to CSS selector or Xpath
 Private Function ToSelector(by_ As By, ByVal value As String) As Dictionary
     Dim data As New Dictionary
-    If (by_ = By.Xpath) Then
+    If (by_ = By.XPath) Then
         'Locator Strategy XPath
         data.Add "using", "xpath"
     Else:
@@ -613,4 +632,3 @@ Private Function Params(ParamArray keysAndValues()) As Dictionary
     Next i
     Set Params = dict
 End Function
-

--- a/WebElement.cls
+++ b/WebElement.cls
@@ -7,7 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
-' TinySeleniumVBA v0.1.0
+' TinySeleniumVBA v0.1.2
 ' A tiny Selenium wrapper written in pure VBA
 '
 ' (c)2021 uezo


### PR DESCRIPTION
To configure browser options, for example to make the browser invisible, users have to build the complex capabilities dictionary.
By adding `Capabilities` object in this commit users can configure without understanding whole spec of WebDriver capabilities.

This is an example to launch browser as headless (invisible) mode.

```vb
' Start web driver
Dim Driver As New WebDriver
Driver.Chrome "C:\Users\uezo\Desktop\chromedriver.exe"
' Configure Capabilities
Dim cap As Capabilities
Set cap = Driver.CreateCapabilities()
cap.AddArgument "--headless"
' Use SetArguments if you want to add multiple arguments
' cap.SetArguments "--headless --xxx -xxx"
' Show Capabilities as JSON for debugging
Debug.Print cap.ToJson()
' Open browser
Driver.OpenBrowser cap
```

See also the sites below to understand the spec of `Capabilities` for each browser.
- Chrome: https://chromedriver.chromium.org/capabilities
- Edge: https://docs.microsoft.com/en-us/microsoft-edge/webdriver-chromium/capabilities-edge-options
